### PR TITLE
:bug: fix loader generation

### DIFF
--- a/personalization-webcomponents/processes/lib/fileGenerator.js
+++ b/personalization-webcomponents/processes/lib/fileGenerator.js
@@ -13,11 +13,12 @@ export function generateLoaderJs(filename, subdirectory, suffix) {
   // replace the correct placeholder with the actual filename
   const loaderJsReplaced = loaderJsTemplate.replaceAll(
     "{{path}}",
-    `${subdirectory}/${filename}`
+    `../${subdirectory}/${filename}`
   );
   // write script to the dist folder as loader.js.template
+  fs.mkdirSync(`./dist/${suffix}`, { recursive: true });
   fs.writeFileSync(
-    path.resolve(`./dist/loader-${suffix}.js`),
+    path.resolve(`./dist/${suffix}/loader.js`),
     loaderJsReplaced,
     {
       encoding: "utf-8",


### PR DESCRIPTION
## Changes
Each loader.js is saved in its own folder. The name loader.js must be retained.



