### PR TITLE
:sparkles: add i18n language change

### DIFF
--- a/personalization-webcomponents/index-checklist-detail.html
+++ b/personalization-webcomponents/index-checklist-detail.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/personalization-webcomponents/index-checklist-overview.html
+++ b/personalization-webcomponents/index-checklist-overview.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/personalization-webcomponents/index-checklist-preview.html
+++ b/personalization-webcomponents/index-checklist-preview.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/personalization-webcomponents/index-my-checklists.html
+++ b/personalization-webcomponents/index-my-checklists.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/personalization-webcomponents/index.html
+++ b/personalization-webcomponents/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/personalization-webcomponents/src/ChecklistPreview.ce.vue
+++ b/personalization-webcomponents/src/ChecklistPreview.ce.vue
@@ -266,6 +266,7 @@ import {
 import SkeletonLoader from "@/components/common/SkeletonLoader.vue";
 import ServiceInfoModal from "@/components/ServiceInfoModal.vue";
 import { useDBSLoginWebcomponentPlugin } from "@/composables/DBSLoginWebcomponentPlugin.ts";
+import { useLanguageObserver } from "@/composables/LanguageObserver.ts";
 import {
   LOCALSTORAGE_KEY_SERVICENAVIGATOR_RESULT,
   QUERY_PARAM_CHECKLIST_ID,
@@ -297,7 +298,8 @@ const selectedService = ref<ChecklistItemServiceNavigatorDTO | null>(null);
 const linkStateMessage = ref("");
 
 const { loggedIn } = useDBSLoginWebcomponentPlugin(_authChangedCallback);
-const { t, locale } = useI18n();
+const { currentLang } = useLanguageObserver();
+const { t, locale, availableLocales } = useI18n();
 
 const props = defineProps<{
   checklistDetailUrl: string;
@@ -307,6 +309,10 @@ const props = defineProps<{
 onMounted(async () => {
   loading.value = true;
   loadingError.value = "";
+
+  if (availableLocales.includes(currentLang.value)) {
+    locale.value = currentLang.value;
+  }
 
   const snResult = getSnResults();
 

--- a/personalization-webcomponents/src/ChecklistPreview.ce.vue
+++ b/personalization-webcomponents/src/ChecklistPreview.ce.vue
@@ -109,6 +109,7 @@
         </p>
         <div style="padding-top: 32px">
           <muc-button
+            v-if="currentLang == DEFAULT_LANGUAGE"
             icon="order-bool-ascending"
             style="margin-right: 16px; margin-bottom: 16px"
             @click="saveChecklistClicked"
@@ -268,6 +269,7 @@ import ServiceInfoModal from "@/components/ServiceInfoModal.vue";
 import { useDBSLoginWebcomponentPlugin } from "@/composables/DBSLoginWebcomponentPlugin.ts";
 import { useLanguageObserver } from "@/composables/LanguageObserver.ts";
 import {
+  DEFAULT_LANGUAGE,
   LOCALSTORAGE_KEY_SERVICENAVIGATOR_RESULT,
   QUERY_PARAM_CHECKLIST_ID,
   QUERY_PARAM_SN_RESULT_ID,

--- a/personalization-webcomponents/src/composables/LanguageObserver.ts
+++ b/personalization-webcomponents/src/composables/LanguageObserver.ts
@@ -1,19 +1,18 @@
-import { ref } from 'vue'
-import { useMutationObserver } from '@vueuse/core'
-
+import { useMutationObserver } from "@vueuse/core";
+import { ref } from "vue";
 
 export function useLanguageObserver() {
-    const currentLang = ref<string>(document.documentElement.lang);
+  const currentLang = ref<string>(document.documentElement.lang);
 
-    useMutationObserver(
-        document.documentElement,
-        (mutations) => {
-            const langMutation = mutations.find(m => m.attributeName === 'lang')
-            if (langMutation) {
-                currentLang.value = document.documentElement.lang
-            }
-        },
-        { attributes: true, attributeFilter: ['lang'], }
-    )
-    return { currentLang };
+  useMutationObserver(
+    document.documentElement,
+    (mutations) => {
+      const langMutation = mutations.find((m) => m.attributeName === "lang");
+      if (langMutation) {
+        currentLang.value = document.documentElement.lang;
+      }
+    },
+    { attributes: true, attributeFilter: ["lang"] }
+  );
+  return { currentLang };
 }

--- a/personalization-webcomponents/src/composables/LanguageObserver.ts
+++ b/personalization-webcomponents/src/composables/LanguageObserver.ts
@@ -1,0 +1,19 @@
+import { ref } from 'vue'
+import { useMutationObserver } from '@vueuse/core'
+
+
+export function useLanguageObserver() {
+    const currentLang = ref<string>(document.documentElement.lang);
+
+    useMutationObserver(
+        document.documentElement,
+        (mutations) => {
+            const langMutation = mutations.find(m => m.attributeName === 'lang')
+            if (langMutation) {
+                currentLang.value = document.documentElement.lang
+            }
+        },
+        { attributes: true, attributeFilter: ['lang'], }
+    )
+    return { currentLang };
+}

--- a/personalization-webcomponents/src/i18n-host.ce.vue
+++ b/personalization-webcomponents/src/i18n-host.ce.vue
@@ -6,6 +6,8 @@
 import { provide } from "vue";
 import { createI18n, I18nInjectionKey } from "vue-i18n";
 
+import {DEFAULT_LANGUAGE} from "@/util/Constants.ts";
+
 import ar from "./util/ar.json";
 import deDE from "./util/de-DE.json";
 import enGB from "./util/en-GB.json";
@@ -19,7 +21,7 @@ import viVN from "./util/vi-VN.json";
 import zhCN from "./util/zh-CN.json";
 
 const i18n = createI18n({
-  locale: "de",
+  locale: DEFAULT_LANGUAGE,
   messages: {
     "de": deDE,
     "en": enGB,

--- a/personalization-webcomponents/src/i18n-host.ce.vue
+++ b/personalization-webcomponents/src/i18n-host.ce.vue
@@ -6,8 +6,7 @@
 import { provide } from "vue";
 import { createI18n, I18nInjectionKey } from "vue-i18n";
 
-import {DEFAULT_LANGUAGE} from "@/util/Constants.ts";
-
+import { DEFAULT_LANGUAGE } from "@/util/Constants.ts";
 import ar from "./util/ar.json";
 import deDE from "./util/de-DE.json";
 import enGB from "./util/en-GB.json";
@@ -23,16 +22,16 @@ import zhCN from "./util/zh-CN.json";
 const i18n = createI18n({
   locale: DEFAULT_LANGUAGE,
   messages: {
-    "de": deDE,
-    "en": enGB,
-    "fr": frFR,
-    "tr": trTR,
-    "es": esES,
-    "uk": ukUA,
-    "ru": ruRU,
-    "ar": ar,
-    "pt": ptPT,
-    "vi": viVN,
+    de: deDE,
+    en: enGB,
+    fr: frFR,
+    tr: trTR,
+    es: esES,
+    uk: ukUA,
+    ru: ruRU,
+    ar: ar,
+    pt: ptPT,
+    vi: viVN,
     "zh-hans": zhCN,
   },
 });

--- a/personalization-webcomponents/src/i18n-host.ce.vue
+++ b/personalization-webcomponents/src/i18n-host.ce.vue
@@ -19,19 +19,19 @@ import viVN from "./util/vi-VN.json";
 import zhCN from "./util/zh-CN.json";
 
 const i18n = createI18n({
-  locale: "de-DE",
+  locale: "de",
   messages: {
-    "de-DE": deDE,
-    "en-GB": enGB,
-    "fr-FR": frFR,
-    "tr-TR": trTR,
-    "es-ES": esES,
-    "uk-UA": ukUA,
-    "ru-RU": ruRU,
-    ar: ar,
-    "pt-PT": ptPT,
-    "vi-VN": viVN,
-    "zh-CN": zhCN,
+    "de": deDE,
+    "en": enGB,
+    "fr": frFR,
+    "tr": trTR,
+    "es": esES,
+    "uk": ukUA,
+    "ru": ruRU,
+    "ar": ar,
+    "pt": ptPT,
+    "vi": viVN,
+    "zh-hans": zhCN,
   },
 });
 

--- a/personalization-webcomponents/src/util/Constants.ts
+++ b/personalization-webcomponents/src/util/Constants.ts
@@ -13,6 +13,8 @@ export const IS_MOBILE_MEDIA_QUERY = "(max-width: 767px)";
 export const IS_MOBILE_SLIDER_MEDIA_QUERY = "(max-width: 1399px)";
 export const IS_RESIZE_SLIDER_CONTENT_MEDIA_QUERY = "(min-width: 1200px)";
 
+export const DEFAULT_LANGUAGE = "de";
+
 let ACCESS_TOKEN: string | undefined = undefined;
 
 export function getChecklistIconBySituationId(situationId: string | undefined) {


### PR DESCRIPTION
Add i18n language change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The web components now default to German language settings.
  * Language handling has been improved so the interface follows the current page language more reliably.

* **Bug Fixes**
  * The “Save as checklist” action is now hidden when it isn’t available for the current language, reducing confusing UI states.
  * Checklist pages now better match the page language for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->