### PR TITLE
:bug: p13n checklist-preview: fix checklist error showing when show-loader=false

### DIFF
--- a/personalization-webcomponents/src/ChecklistPreview.ce.vue
+++ b/personalization-webcomponents/src/ChecklistPreview.ce.vue
@@ -183,7 +183,7 @@
             </ul>
           </div>
 
-          <div v-else>
+          <div v-else-if="loadingError">
             <muc-callout type="error">
               <template #header>
                 Die Checkliste kann nicht geladen werden.


### PR DESCRIPTION
see title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checklist preview messaging so the loading error appears only when an actual loading error occurs.
  * Prevented the error callout from displaying when other checklist states—such as loading, storage issues, or no results—apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->