### PR TITLE
:bug: send Vary Origin for login-webcomponent CORS responses

### DIFF
--- a/login-webcomponent/README.md
+++ b/login-webcomponent/README.md
@@ -12,6 +12,8 @@ The Docker-Image consists of a nginx web server which hosts the built version of
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | ALLOW_ORIGIN | The allowed origins formatted for the nginx map directive. E.g. `~^https?://(.*\.)?muenchen.de(:\d+)?$ $http_origin;` to allow all subdomains of muenchen.de. Can contain multiple entries. | -       |
 
+Static assets under `/src/` send `Access-Control-Allow-Origin` based on the request `Origin` (via `ALLOW_ORIGIN`). Nginx also sends `Vary: Origin` so browsers/CDNs do not reuse a cached module (and its ACAO) from one embedder host on another.
+
 ## Usage
 
 1. Add Import to page:

--- a/login-webcomponent/docker/nginx/files.conf
+++ b/login-webcomponent/docker/nginx/files.conf
@@ -1,12 +1,17 @@
 location /src/ {
-    add_header 'Access-Control-Allow-Origin' $allowed_origin;
+    add_header 'Access-Control-Allow-Origin' $allowed_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+    # ACAO reflects Origin via $allowed_origin — caches must not reuse one host's
+    # response for another (zms-test vs zms-dev), or the module script fails CORS.
+    add_header 'Vary' 'Origin' always;
     expires 365d;
     add_header Cache-Control "public, no-transform, max-age=31536000" always;
 }
 
-location ~ ^/loader-.*\.js$ {
-    add_header 'Access-Control-Allow-Origin' $allowed_origin;
+# Root loader.js and optional hashed loader-*.js entrypoints
+location ~ ^/loader(-.*)?\.js$ {
+    add_header 'Access-Control-Allow-Origin' $allowed_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
-    add_header Cache-Control 'no-cache';
+    add_header 'Vary' 'Origin' always;
+    add_header Cache-Control 'no-cache' always;
 }

--- a/login-webcomponent/docker/nginx/files.conf
+++ b/login-webcomponent/docker/nginx/files.conf
@@ -1,17 +1,18 @@
 location /src/ {
     add_header 'Access-Control-Allow-Origin' $allowed_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
-    # ACAO reflects Origin via $allowed_origin — caches must not reuse one host's
-    # response for another (zms-test vs zms-dev), or the module script fails CORS.
     add_header 'Vary' 'Origin' always;
     expires 365d;
     add_header Cache-Control "public, no-transform, max-age=31536000" always;
 }
-
-# Root loader.js and optional hashed loader-*.js entrypoints
-location ~ ^/loader(-.*)?\.js$ {
+location = /loader.js {
     add_header 'Access-Control-Allow-Origin' $allowed_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
     add_header 'Vary' 'Origin' always;
-    add_header Cache-Control 'no-cache' always;
+}
+location ~ ^/loader-.*\.js$ {
+    add_header 'Access-Control-Allow-Origin' $allowed_origin always;
+    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+    add_header 'Vary' 'Origin' always;
+    add_header Cache-Control 'no-cache';
 }


### PR DESCRIPTION
## Changes

- Add `Vary: Origin` next to the dynamic CORS header on `/src/` and loader scripts so a cached response from one embedder host is not reused on another (button then fails to load). Example: load the button on `zms-demo`, then open `zms-test` in another tab — without this, the script is still cached with ACAO for demo and the button disappears on test.
- Use `always` on the CORS headers
- Also match root `loader.js`, not only `loader-*.js`

## Reference

Issue: n/a

## Checklist

### General

- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English
- [x] Removed waste on branch (e.g. `console.log`), see [code quality tooling](https://refarch.oss.muenchen.de/templates/develop#code-quality)